### PR TITLE
Switch from CURL* back to URL* processors

### DIFF
--- a/Authy/Authy.download.recipe
+++ b/Authy/Authy.download.recipe
@@ -15,7 +15,7 @@
     <array>
 	<dict>
 	    <key>Processor</key>
-	    <string>CURLTextSearcher</string>
+	    <string>URLTextSearcher</string>
 	    <key>Arguments</key>
 	    <dict>
 		<key>url</key>

--- a/GoPro/Quik.download.recipe
+++ b/GoPro/Quik.download.recipe
@@ -15,7 +15,7 @@
     <array>
     <dict>
       <key>Processor</key>
-      <string>CURLDownloader</string>
+      <string>URLDownloader</string>
       <key>Arguments</key>
       <dict>
         <key>url</key>

--- a/NVivo/NVivo11.download.recipe
+++ b/NVivo/NVivo11.download.recipe
@@ -15,7 +15,7 @@
     <array>
     <dict>
       <key>Processor</key>
-      <string>CURLDownloader</string>
+      <string>URLDownloader</string>
       <key>Arguments</key>
       <dict>
         <key>url</key>

--- a/Osculator/Osculator.download.recipe
+++ b/Osculator/Osculator.download.recipe
@@ -15,7 +15,7 @@
     <array>
     <dict>
       <key>Processor</key>
-      <string>CURLTextSearcher</string>
+      <string>URLTextSearcher</string>
       <key>Arguments</key>
       <dict>
         <key>url</key>
@@ -26,7 +26,7 @@
     </dict>
     <dict>
       <key>Processor</key>
-      <string>CURLDownloader</string>
+      <string>URLDownloader</string>
       <key>Arguments</key>
       <dict>
         <key>url</key>


### PR DESCRIPTION
As of [AutoPkg 0.6.0](https://github.com/autopkg/autopkg/tree/v0.6.0), it's safe to switch back to the "standard" URLDownloader and URLTextSearcher processors.