### PR TITLE
Update FilemakerUpdateURLProcessor for AutoPkg 2.x compatibility

### DIFF
--- a/FileMaker/FilemakerUpdateURLProcessor.py
+++ b/FileMaker/FilemakerUpdateURLProcessor.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # FilemakerUpdateURLProcessor.py
 # Fetches information about the latest FileMaker Pro updater.
 #


### PR DESCRIPTION
This PR updates FilemakerUpdateURLProcessor to use URLGetter and Python 3 urlsplit, in order to maintain compatibility with AutoPkg 1.x while adding compatibility for AutoPkg 2.x (due to be released early next month).

Verbose log:
```
% autopkg run -vvcq FileMakerUpdater.download.recipe
Processing FileMakerUpdater.download.recipe...
WARNING: FileMakerUpdater.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
FilemakerUpdateURLProcessor
{'Input': {'major_version': '16'}}
FilemakerUpdateURLProcessor: URL found 'https://fmdl.filemaker.com/UPDT/16/fmp_updater_16.0.5.500.zip'
{'Output': {'package_file': 'fmp_updater_16.0.5.500.zip',
            'package_name': 'FileMaker Pro - 16.0.5',
            'url': 'https://fmdl.filemaker.com/UPDT/16/fmp_updater_16.0.5.500.zip',
            'version': '16.0.5.500'}}
URLDownloader
{'Input': {'url': 'https://fmdl.filemaker.com/UPDT/16/fmp_updater_16.0.5.500.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Mon, 05 Mar 2018 19:15:49 GMT
URLDownloader: Storing new ETag header: "ec177-566af2758e340"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.nzmacgeek.download.filemakerupdater/downloads/fmp_updater_16.0.5.500.zip
{'Output': {'download_changed': True,
            'etag': '"ec177-566af2758e340"',
            'last_modified': 'Mon, 05 Mar 2018 19:15:49 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.nzmacgeek.download.filemakerupdater/downloads/fmp_updater_16.0.5.500.zip',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.nzmacgeek.download.filemakerupdater/downloads/fmp_updater_16.0.5.500.zip'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.nzmacgeek.download.filemakerupdater/receipts/FileMakerUpdater.download-receipt-20200119-233432.plist

The following new items were downloaded:
    Download Path                                                                                                          
    -------------                                                                                                          
    ~/Library/AutoPkg/Cache/com.github.nzmacgeek.download.filemakerupdater/downloads/fmp_updater_16.0.5.500.zip  
```