### PR TITLE
Adjust PkgCreator arguments

### DIFF
--- a/Authy/Authy.pkg.recipe
+++ b/Authy/Authy.pkg.recipe
@@ -45,10 +45,10 @@
         <string>PkgCreator</string>
         <key>Arguments</key>
         <dict>
-          <key>pkgname</key>
-          <string>%NAME%-%version%</string>
           <key>pkg_request</key>
           <dict>
+            <key>pkgname</key>
+            <string>%NAME%-%version%</string>
             <key>pkgdir</key>
             <string>%RECIPE_CACHE_DIR%</string>
             <key>id</key>

--- a/NVivo/NVivo11.pkg.recipe
+++ b/NVivo/NVivo11.pkg.recipe
@@ -45,10 +45,10 @@
         <string>PkgCreator</string>
         <key>Arguments</key>
         <dict>
-          <key>pkgname</key>
-          <string>%NAME%-%version%</string>
           <key>pkg_request</key>
           <dict>
+            <key>pkgname</key>
+            <string>%NAME%-%version%</string>
             <key>pkgdir</key>
             <string>%RECIPE_CACHE_DIR%</string>
             <key>id</key>

--- a/Osculator/Osculator.pkg.recipe
+++ b/Osculator/Osculator.pkg.recipe
@@ -65,10 +65,10 @@
         <string>PkgCreator</string>
         <key>Arguments</key>
         <dict>
-          <key>pkgname</key>
-          <string>%NAME%-%version%</string>
           <key>pkg_request</key>
           <dict>
+            <key>pkgname</key>
+            <string>%NAME%-%version%</string>
             <key>pkgdir</key>
             <string>%RECIPE_CACHE_DIR%</string>
             <key>id</key>


### PR DESCRIPTION
`pkgname` is [intended](https://github.com/autopkg/autopkg/blob/e36d5cba2823dbdfcb69a41a38b1aef9fb76121c/Code/autopkgserver/autopkgserver#L47) to be in the `pkg_request` dictionary, not as a standalone argument for [PkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-PkgCreator).