### PR TITLE
Update Python path to reflect changes in macOS 12.3+

### DIFF
--- a/FileMaker/FilemakerUpdateExtractor.py
+++ b/FileMaker/FilemakerUpdateExtractor.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/local/autopkg/python
 # FilemakerUpdateDMGExtractor.py
 # Extracts a FileMaker updater package from a given DMG.
 #
@@ -30,6 +30,7 @@ from autopkglib.DmgMounter import DmgMounter
 
 __all__ = ["FilemakerUpdateExtractor"]
 
+
 class FilemakerUpdateExtractor(DmgMounter):
     """Extracts update pkg from given DMG or ZIP"""
 
@@ -37,18 +38,16 @@ class FilemakerUpdateExtractor(DmgMounter):
     input_variables = {
         "downloaded_file": {
             "required": True,
-            "description":
-                "The path to the DMG or ZIP downloaded from the FileMaker website"
+            "description": "The path to the DMG or ZIP downloaded from the FileMaker website",
         }
     }
     output_variables = {
-        "pkg_path": {
-            "description": "Outputs the extracted package path."
-        }
+        "pkg_path": {"description": "Outputs the extracted package path."}
     }
+
     def find_pkg(self, dir_path):
-        '''Return path to the first package in dir_path'''
-        #pylint: disable=no-self-use
+        """Return path to the first package in dir_path"""
+        # pylint: disable=no-self-use
         for item in os.listdir(dir_path):
             if item.endswith(".pkg"):
                 return os.path.join(dir_path, item)
@@ -63,11 +62,13 @@ class FilemakerUpdateExtractor(DmgMounter):
     def main(self):
         if self.is_zip(self.env["downloaded_file"]):
             try:
-                with zipfile.ZipFile(self.env["downloaded_file"], 'r') as zf:
+                with zipfile.ZipFile(self.env["downloaded_file"], "r") as zf:
                     contents = zf.namelist()
-                    pkgs = [f for f in contents if fnmatch.fnmatch(f, '*.pkg')]
+                    pkgs = [f for f in contents if fnmatch.fnmatch(f, "*.pkg")]
                     zf.extract(pkgs[0], self.env["RECIPE_CACHE_DIR"])
-                    self.env["pkg_path"] = os.path.join(self.env["RECIPE_CACHE_DIR"], os.path.basename(pkgs[0]))
+                    self.env["pkg_path"] = os.path.join(
+                        self.env["RECIPE_CACHE_DIR"], os.path.basename(pkgs[0])
+                    )
             except Exception as err:
                 raise ProcessorError(err)
         else:
@@ -76,12 +77,15 @@ class FilemakerUpdateExtractor(DmgMounter):
             # unmounted.
             try:
                 pkg = self.find_pkg(mount_point)
-                shutil.copy(pkg, self.env['RECIPE_CACHE_DIR'])
-                self.env["pkg_path"] = os.path.join(self.env['RECIPE_CACHE_DIR'], os.path.basename(pkg))
+                shutil.copy(pkg, self.env["RECIPE_CACHE_DIR"])
+                self.env["pkg_path"] = os.path.join(
+                    self.env["RECIPE_CACHE_DIR"], os.path.basename(pkg)
+                )
             except Exception as err:
                 raise ProcessorError(err)
             finally:
                 self.unmount(self.env["downloaded_file"])
+
 
 if __name__ == "__main__":
     PROCESSOR = FilemakerUpdateExtractor()

--- a/Shared_Recipes/Rsync.py
+++ b/Shared_Recipes/Rsync.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/local/autopkg/python
 #
 #  Copyright (c) 2015, Facebook, Inc.
 #  All rights reserved.
@@ -22,45 +22,47 @@ __all__ = ["Rsync"]
 
 
 class Rsync(Processor):
-  """Rsyncs a file/directory to another file/directory"""
-  description = __doc__
-  input_variables = {
-    "source_path": {
-      "required": True,
-      "description": ("Path to file or directory to copy from.")
-    },
-    "destination_path": {
-      "required": True,
-      "description": ("Path to file or directory to copy to.")
-    },
-    "rsync_arguments": {
-      "required": False,
-      "description": ("Arguments passed to rsync directly.")
-    },
-    "rsync_path": {
-      "required": False,
-      "description": ("Custom path to rsync. Defaults to /usr/bin/rsync.")
+    """Rsyncs a file/directory to another file/directory"""
+
+    description = __doc__
+    input_variables = {
+        "source_path": {
+            "required": True,
+            "description": ("Path to file or directory to copy from."),
+        },
+        "destination_path": {
+            "required": True,
+            "description": ("Path to file or directory to copy to."),
+        },
+        "rsync_arguments": {
+            "required": False,
+            "description": ("Arguments passed to rsync directly."),
+        },
+        "rsync_path": {
+            "required": False,
+            "description": ("Custom path to rsync. Defaults to /usr/bin/rsync."),
+        },
     }
-  }
-  output_variables = {
-  }
+    output_variables = {}
 
-  __doc__ = description
+    __doc__ = description
 
-  def main(self):
-    rsync_location = self.env.get("rsync_path", "/usr/bin/rsync")
-    rsync_args = self.env.get("rsync_arguments", [])
-    
-    cmd = [rsync_location] + rsync_args + [self.env["source_path"],
-           self.env["destination_path"]]
-    proc = subprocess.Popen(cmd,
-                            stdout=subprocess.PIPE,
-                            stderr=subprocess.PIPE)
-    (rout, rerr) = proc.communicate()
-    if rerr:
-        raise ProcessorError(rerr)
-    self.output(rout)
+    def main(self):
+        rsync_location = self.env.get("rsync_path", "/usr/bin/rsync")
+        rsync_args = self.env.get("rsync_arguments", [])
+
+        cmd = (
+            [rsync_location]
+            + rsync_args
+            + [self.env["source_path"], self.env["destination_path"]]
+        )
+        proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        (rout, rerr) = proc.communicate()
+        if rerr:
+            raise ProcessorError(rerr)
+        self.output(rout)
+
 
 if __name__ == "__main__":
-  PROCESSOR = Rsync()
-  PROCESSOR.execute_shell()
+    PROCESSOR = Rsync()
+    PROCESSOR.execute_shell()

--- a/Shared_Recipes/ShareMounter.py
+++ b/Shared_Recipes/ShareMounter.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/local/autopkg/python
 #
 # Copyright 2016 William McGrath
 #
@@ -28,45 +28,35 @@ from autopkglib import Processor, ProcessorError
 
 __all__ = ["ShareMounter"]
 
+
 class ShareMounter(Processor):
     """Base class for Processors that need to mount file shares."""
+
     description = __doc__
     input_variables = {
-        "file_share": {
-            "required": True,
-            "description":
-                "Full path to share to mount."
-        },
+        "file_share": {"required": True, "description": "Full path to share to mount."},
         "credential_file": {
             "required": False,
-            "description":
-                "Full path to a plist containg the username and password to connect with, if necessary."
+            "description": "Full path to a plist containg the username and password to connect with, if necessary.",
         },
         "mount_point": {
             "required": False,
-            "description":
-                "Path to a potential mount_point for share."
+            "description": "Path to a potential mount_point for share.",
         },
         "unmount": {
             "required": False,
-            "description":
-                "Specify this parameter if you want to unmount."
-        }
+            "description": "Specify this parameter if you want to unmount.",
+        },
     }
-    output_variables = {
-        "mount_point": {
-            "description":
-                "Outputs mount point path."
-        }
-    }
+    output_variables = {"mount_point": {"description": "Outputs mount point path."}}
 
     def __init__(self, data=None, infile=None, outfile=None):
         super(ShareMounter, self).__init__(data, infile, outfile)
 
     def is_mount_point_writeable(self, mount_point):
         try:
-            tempfile = os.path.join(mount_point, 'tmp')
-            open(tempfile, 'w')
+            tempfile = os.path.join(mount_point, "tmp")
+            open(tempfile, "w")
         except IOError:
             return False
         else:
@@ -74,24 +64,24 @@ class ShareMounter(Processor):
             return True
 
     def get_share_credentials(self):
-        if 'credential_file' not in self.env:
-            return ''
+        if "credential_file" not in self.env:
+            return ""
         else:
             try:
-                cfile = open(self.env['credential_file'])
+                cfile = open(self.env["credential_file"])
                 data = cfile.read()
                 cfile.close()
                 plist = FoundationPlist.readPlistFromString(data)
-                username = plist.get('Username')
-                password = plist.get('Password')
+                username = plist.get("Username")
+                password = plist.get("Password")
             except Exception as err:
                 raise ProcessorError(err)
             return "%s:%s@" % (username, password)
 
     def mount(self, sharepath, mount_point=None):
-        if 'fsmounts' not in self.env:
-            self.env['fsmounts'] = dict()
-        if sharepath in self.env['fsmounts']:
+        if "fsmounts" not in self.env:
+            self.env["fsmounts"] = dict()
+        if sharepath in self.env["fsmounts"]:
             raise ProcessorError("%s is already mounted." % sharepath)
 
         try:
@@ -99,72 +89,78 @@ class ShareMounter(Processor):
                 if self.is_mount_point_writeable(mount_point) is not True:
                     mount_point = None
             if mount_point is None:
-                mount_point = tempfile.mkdtemp(prefix='ShareMounter')
+                mount_point = tempfile.mkdtemp(prefix="ShareMounter")
         except Exception as e:
             raise ProcessorError("Could not write to mount point.")
 
         # do a string substitution on the share string just in case
         creds = self.get_share_credentials()
-        thesharepath = re.sub(r'!!CREDENTIALS!!', creds, sharepath)
+        thesharepath = re.sub(r"!!CREDENTIALS!!", creds, sharepath)
         try:
-            proc = subprocess.Popen(("/sbin/mount_smbfs",
-                                     thesharepath,
-                                     mount_point),
-                                     stdout=subprocess.PIPE,
-                                     stderr=subprocess.PIPE,
-                                     stdin=subprocess.PIPE)
+            proc = subprocess.Popen(
+                ("/sbin/mount_smbfs", thesharepath, mount_point),
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                stdin=subprocess.PIPE,
+            )
             (stdout, stderr) = proc.communicate()
         except OSError as err:
             raise ProcessorError(
                 "mount execution failed with error code %d: %s"
-                % (err.errno, err.strerror))
+                % (err.errno, err.strerror)
+            )
 
         if proc.returncode != 0:
-            raise ProcessorError("mounting %s failed: %s (#%d)" % (sharepath, stdout, proc.returncode))
+            raise ProcessorError(
+                "mounting %s failed: %s (#%d)" % (sharepath, stdout, proc.returncode)
+            )
 
         self.env["fsmounts"][sharepath] = mount_point
         self.output("mounted %s at %s" % (sharepath, mount_point))
         self.env["mount_point"] = mount_point
 
     def unmount(self, sharepath):
-        if 'fsmounts' in self.env:
-            if sharepath not in self.env['fsmounts']:
+        if "fsmounts" in self.env:
+            if sharepath not in self.env["fsmounts"]:
                 raise ProcessorError("%s was not mounted" % sharepath)
 
             try:
-                proc = subprocess.Popen(("/sbin/umount",
-                                    self.env["fsmounts"][sharepath]),
-                                    stdout=subprocess.PIPE,
-                                    stderr=subprocess.PIPE)
+                proc = subprocess.Popen(
+                    ("/sbin/umount", self.env["fsmounts"][sharepath]),
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                )
                 (stdout, stderr) = proc.communicate()
             except OSError as err:
                 raise ProcessorError(
                     "unmount execution failed with error code %d: %s"
-                    % (err.errno, err.strerror))
+                    % (err.errno, err.strerror)
+                )
 
             if proc.returncode != 0:
                 raise ProcessorError("unmounting %s failed: %s" % (sharepath, stdout))
 
-            del self.env['fsmounts'][sharepath]
+            del self.env["fsmounts"][sharepath]
             self.output("unmounted %s" % sharepath)
         else:
             raise ProcessorError("%s was not mounted" % sharepath)
 
     def main(self):
-        if 'unmount' in self.env:
+        if "unmount" in self.env:
             try:
-                self.unmount(self.env['file_share'])
+                self.unmount(self.env["file_share"])
             except Exception as err:
                 raise ProcessorError(err)
         else:
             mount_point = None
             if "mountpoint" in self.env:
-                mount_point = self.env['mount_point']
+                mount_point = self.env["mount_point"]
 
             try:
-                self.mount(self.env['file_share'], mount_point)
+                self.mount(self.env["file_share"], mount_point)
             except Exception as err:
                 raise ProcessorError(err)
+
 
 if __name__ == "__main__":
     PROCESSOR = ShareMounter()

--- a/Shared_Recipes/TemplateVersioner.py
+++ b/Shared_Recipes/TemplateVersioner.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/local/autopkg/python
 #
 # Copyright 2016 William McGrath
 #
@@ -33,50 +33,52 @@ __all__ = ["TemplateVersioner"]
 
 class TemplateVersioner(Processor):
     """Provides a Version Number for use with the Templates"""
+
     description = __doc__
     input_variables = {
         "mount_point": {
             "description": "File share mount point containing templates.",
-            "required": True
+            "required": True,
         },
         "file_exclusions": {
             "description": "File name globs to ignore in file search.",
-            "required": False
+            "required": False,
         },
-        "save_checksum": {
-            "description": "Update checksum file.",
-            "required": False
-        },
+        "save_checksum": {"description": "Update checksum file.", "required": False},
         "checksum": {
             "description": "Latest checksum of template directory",
-            "required": False
-        }
+            "required": False,
+        },
     }
     output_variables = {
         "version": "Output of an appropriate version number for given params.",
         "stop_processing": "Trigger variable to stop processing recipe.",
-        "checksum": "Latest directory checksum"
+        "checksum": "Latest directory checksum",
     }
 
     __doc__ = description
 
     def update_checksum_file(self):
-        if 'checksum' not in self.env:
-            raise ProcessorError('checksum missing')
-        checksum_file = os.path.join(self.env['RECIPE_CACHE_DIR'], 'checksum')
-        cf = open(checksum_file, 'w')
-        cf.write(self.env['checksum'])
+        if "checksum" not in self.env:
+            raise ProcessorError("checksum missing")
+        checksum_file = os.path.join(self.env["RECIPE_CACHE_DIR"], "checksum")
+        cf = open(checksum_file, "w")
+        cf.write(self.env["checksum"])
         cf.close()
 
     def check_for_changes(self):
         m = hashlib.md5()
         changed = False
-        for root, dirs, files in os.walk(self.env['mount_point']):
+        for root, dirs, files in os.walk(self.env["mount_point"]):
             for file_read in files:
                 if "file_exclusions" in self.env:
-                    for excl in self.env['file_exclusions']:
+                    for excl in self.env["file_exclusions"]:
                         if fnmatch.fnmatch(file_read, excl):
-                            self.output("Excluding %s as it matches a file_exclusion (%s)." % (file_read, excl), verbose_level=2)
+                            self.output(
+                                "Excluding %s as it matches a file_exclusion (%s)."
+                                % (file_read, excl),
+                                verbose_level=2,
+                            )
                             continue
                 full_path = os.path.join(root, file_read)
                 for line in open(full_path).readlines():
@@ -85,7 +87,7 @@ class TemplateVersioner(Processor):
         oldchecksum = ""
         self.output("Old checksum: %s", oldchecksum)
         self.output("New checksum: %s", newchecksum)
-        checksum_file = os.path.join(self.env['RECIPE_CACHE_DIR'], 'checksum')
+        checksum_file = os.path.join(self.env["RECIPE_CACHE_DIR"], "checksum")
         if os.path.isfile(checksum_file):
             oldchecksum_f = open(checksum_file)
             oldchecksum = oldchecksum_f.read()
@@ -98,12 +100,13 @@ class TemplateVersioner(Processor):
         return changed
 
     def main(self):
-        if 'save_checksum' in self.env:
+        if "save_checksum" in self.env:
             self.update_checksum_file()
         else:
             if self.check_for_changes() is False:
                 self.env["stop_processing"] = True
-        self.env["version"] = datetime.strftime(datetime.now(), '%y%m%d') + '.0'
+        self.env["version"] = datetime.strftime(datetime.now(), "%y%m%d") + ".0"
+
 
 if __name__ == "__main__":
     PROCESSOR = TemplateVersioner()


### PR DESCRIPTION
As of macOS Monterey 12.3, the version of Python 2 that shipped with macOS located at `/usr/bin/python` [has been removed](https://developer.apple.com/documentation/macos-release-notes/macos-12_3-release-notes). More context can be found in some posts from Mac admins at the beginning of 2022, aggregated [here](https://scriptingosx.com/2022/03/macos-monterey-12-3-removes-python-2-link-collection/).

Since [version 2.0.2](https://github.com/autopkg/autopkg/releases/tag/v2.0.2), AutoPkg's installer has included its own Python 3 framework, symlinked from `/usr/local/autopkg/python`. Similarly, Munki ships with its own Python 3 framework, symlinked from `/usr/local/munki/munki-python`. This pull request adjusts the shebang and interpreter paths of processors, pre/post install scripts, and other files to replace `/usr/bin/python` with the AutoPkg or Munki Python 3 symlinks as appropriate.

NOTE: Because AutoPkg processors are imported as modules by AutoPkg and not executed directly, processors' shebang has no effect in normal usage. However: (a) some people execute processors directly during testing, and these tests won't work unless the shebang points to a valid Python 3, and (b) having instances of `/usr/bin/python` in the codebase could lead to confusion for people not deeply familiar with processor behavior.