### PR TITLE
Removal of unused `options` from PkgCreator arguments

### DIFF
--- a/Authy/Authy.pkg.recipe
+++ b/Authy/Authy.pkg.recipe
@@ -53,8 +53,6 @@
             <string>%RECIPE_CACHE_DIR%</string>
             <key>id</key>
             <string>com.authy.installer</string>
-            <key>options</key>
-            <string>purge_ds_store</string>
             <key>chown</key>
             <array>
               <dict>

--- a/NVivo/NVivo11.pkg.recipe
+++ b/NVivo/NVivo11.pkg.recipe
@@ -53,8 +53,6 @@
             <string>%RECIPE_CACHE_DIR%</string>
             <key>id</key>
             <string>com.qsrinternational.nvivo.11.pkg</string>
-            <key>options</key>
-            <string>purge_ds_store</string>
             <key>chown</key>
             <array>
               <dict>

--- a/Osculator/Osculator.pkg.recipe
+++ b/Osculator/Osculator.pkg.recipe
@@ -73,8 +73,6 @@
             <string>%RECIPE_CACHE_DIR%</string>
             <key>id</key>
             <string>net.osculator.pkg</string>
-            <key>options</key>
-            <string>purge_ds_store</string>
             <key>chown</key>
             <array>
               <dict>


### PR DESCRIPTION
Hundreds of recipes dating from the very beginning of AutoPkg use the `options` key in the `pkg_request` argument of PkgCreator:

```xml
<key>options</key>
<string>purge_ds_store</string>
```

However, this key doesn't serve any purpose at all. The `options` key is ignored and not passed along to `pkgbuild`, regardless of its presence or contents. It appears that this has been the case since the very first public release of AutoPkg 0.1.0!

So this pull request (one of over 100) formally ends this practice and remove the unused and unneeded `options` key from all recipes in the AutoPkg org that use PkgCreator.

Thanks for considering!

_This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.2.0._